### PR TITLE
Any action can be passed to a reducer

### DIFF
--- a/src/_types.d.ts
+++ b/src/_types.d.ts
@@ -28,3 +28,9 @@ export type DeepWriteable<T> = T extends Set<any> | Map<any, any> | Function | D
         : T extends ReadonlyArray<infer U>
             ? Array<U>
             : T
+
+export type AnyAction = {
+    type: string;
+    payload?: any;
+    meta?: any;
+}

--- a/src/immer.d.ts
+++ b/src/immer.d.ts
@@ -1,4 +1,4 @@
-import type {AbstractAction, ActionUnionToDictionary, DeepWriteable} from './_types';
+import type {AbstractAction, ActionUnionToDictionary, AnyAction, DeepWriteable} from './_types';
 
 /**
  * Handle actions `immer` way
@@ -32,4 +32,4 @@ export declare function handleActions<S, A extends AbstractAction>(
         [T in keyof ActionUnionToDictionary<A>]?: (state: DeepWriteable<S>, action: ActionUnionToDictionary<A>[T]) => S | void;
     },
     state: S,
-): (state: S | undefined, action: A) => S;
+): (state: S | undefined, action: A | AnyAction) => S;

--- a/src/reducer.d.ts
+++ b/src/reducer.d.ts
@@ -1,4 +1,4 @@
-import type {AbstractAction, ActionUnionToDictionary, DeepReadonly} from './_types';
+import type {AbstractAction, ActionUnionToDictionary, AnyAction, DeepReadonly} from './_types';
 
 /**
  * Handle actions `redux-actions` way
@@ -30,4 +30,4 @@ export declare function handleActions<S, A extends AbstractAction>(
         [T in keyof ActionUnionToDictionary<A>]?: (state: DeepReadonly<S>, action: ActionUnionToDictionary<A>[T]) => S;
     },
     state: S,
-): (state: S | undefined, action: A) => S;
+): (state: S | undefined, action: A | AnyAction) => S;

--- a/test/immer.test.ts
+++ b/test/immer.test.ts
@@ -56,7 +56,6 @@ describe('immer', () => {
         const st: State = {
             ...defaultState,
         };
-        // @ts-expect-error testing unknown action
         const result = reducer(st, {type: 'unknown', payload: 'whatever'});
 
         expect(result).toEqual(st)

--- a/test/reducer.test.ts
+++ b/test/reducer.test.ts
@@ -45,7 +45,6 @@ describe('reducer', () => {
         const st: State = {
             ...defaultState,
         };
-        // @ts-expect-error testing unknown action
         const result = reducer(st, {type: 'unknown', payload: 'whatever'});
 
         expect(result).toEqual(st)


### PR DESCRIPTION
According to typescript types `combineReducer` expects any reducer to accept whatever action you pass to it.

Let's make it happen.